### PR TITLE
feat: Reporting node_version to Snapshotter API now in initial submission

### DIFF
--- a/snapshotter/utils/generic_worker.py
+++ b/snapshotter/utils/generic_worker.py
@@ -193,7 +193,7 @@ class GenericAsyncWorker:
         snapshot_bytes = snapshot_json.encode('utf-8')
         snapshot_cid = cid_sha256_hash(snapshot_bytes)
 
-        request_, signature = self.generate_signature(snapshot_cid, epoch.epochId, project_id)
+        request_, signature = self.generate_signature(snapshot_cid, epoch.epochId, f"{project_id}|{settings.node_version}")
         # submit to relayer
         try:
             response = await self._client.post(
@@ -202,7 +202,7 @@ class GenericAsyncWorker:
                     'slotId': settings.slot_id,
                     'request': request_,
                     'signature': '0x' + str(signature.hex()),
-                    'projectId': project_id,
+                    'projectId': f"{project_id}|{settings.node_version}",
                     'epochId': epoch.epochId,
                     'snapshotCid': snapshot_cid,
                     'contractAddress': self.protocol_state_contract_address,

--- a/snapshotter/utils/models/settings_model.py
+++ b/snapshotter/utils/models/settings_model.py
@@ -103,6 +103,7 @@ class Settings(BaseModel):
     ipfs: IPFSConfig
     web3storage: Web3Storage
     anchor_chain_rpc: RPCConfigBase
+    node_version: str
 
 
 # Projects related models


### PR DESCRIPTION
- Using release node version from `settings.example.json`
- Reporting node version to Snapshotter API in dummy submissions